### PR TITLE
Warning about missing WT settings data

### DIFF
--- a/assets/css/yk-mt-core.css
+++ b/assets/css/yk-mt-core.css
@@ -84,6 +84,14 @@ Utility classes
 	display: none !important;
 }
 
+.yk-mt-warning {
+	color: #ff8c00;
+}
+
+.yk-mt-error {
+	color: #f00;
+}
+
 /*********
 Components
 *********/

--- a/core/functions.php
+++ b/core/functions.php
@@ -830,12 +830,15 @@ function yk_mt_form_text( $title, $name, $value ='', $max_length = 60, $required
 /**
  * @param $title
  * @param $name
- * @param string $value
+ * @param string $previous_value
  * @param array $options
+ * @param string $placeholder
+ * @param bool $previous_value_is_key
+ * @param array $keys_to_disable
  *
  * @return string
  */
-function yk_mt_form_select( $title, $name, $previous_value ='', $options = [], $placeholder = '', $previous_value_is_key = false ) {
+function yk_mt_form_select( $title, $name, $previous_value ='', $options = [], $placeholder = '', $previous_value_is_key = false, $keys_to_disable = [] ) {
 
     $name = 'yk-mt-' . $name;
 
@@ -857,7 +860,9 @@ function yk_mt_form_select( $title, $name, $previous_value ='', $options = [], $
 
         $selected = selected( $previous_value, $compare_against, false );
 
-		$html .= sprintf( '<option value="%1$s" %3$s>%2$s</option>', esc_attr( $key ), esc_attr( $value ), $selected );
+        $disabled = ( true === in_array( $key, $keys_to_disable ) ) ? ' disabled' : '';
+
+		$html .= sprintf( '<option value="%1$s" %4$s %3$s>%2$s</option>', esc_attr( $key ), esc_attr( $value ), $selected, $disabled );
 	}
 
 	$html .= '</select></div>';

--- a/core/shortcode-meal-tracker.php
+++ b/core/shortcode-meal-tracker.php
@@ -196,7 +196,7 @@ function yk_mt_shortcode_meal_tracker_settings( $target = NULL ) {
 	$calories_html = '';
 
 	/**
-	 * Do we have an sources to fetch calorie allowances from?
+	 * Do we have any sources to fetch calorie allowances from?
 	 * */
 	$calorie_sources = yk_mt_user_calories_sources();
 
@@ -210,12 +210,21 @@ function yk_mt_shortcode_meal_tracker_settings( $target = NULL ) {
 
 	} else {
 
+		$keys_to_disable = [];
+
+		if ( yk_mt_wlt_enabled_for_mt() &&
+		        true === empty( ws_ls_harris_benedict_calculate_calories( get_current_user_id() ) ) ) {
+			$calories_html .= '<p class="yk-mt-warning">' . __( '<strong>Please note</strong>: If you wish to specify Weight Tracker as your target source, then you must complete your Weight Tracker profile (e.g. height, DoB, etc) so your suggested calorie intake can be calculated.', YK_MT_SLUG ) . '</p>';
+			$keys_to_disable = [ 'wlt' ];
+		}
+
 		$calories_html .= yk_mt_form_select( __( 'Calorie target source', YK_MT_SLUG ),
 											'calorie-source',
 													yk_mt_settings_get( 'calorie-source' ),
 													$calorie_sources,
 													'',
-													true
+													true,
+													$keys_to_disable
 		);
 
 		$calories_html .= yk_mt_form_number( __( 'Specify your own target: ', YK_MT_SLUG ),

--- a/meal-tracker.php
+++ b/meal-tracker.php
@@ -5,9 +5,9 @@ defined('ABSPATH') or die("Jog on!");
 /**
  * Plugin Name:         Meal Tracker
  * Description:         Allow your users to track their meals and calorie intake for a given day.
- * Version:             3.1.4
+ * Version:             3.1.5
  * Requires at least:   5.7
- * Tested up to:		6.3.1
+ * Tested up to:		6.3.2
  * Requires PHP:        7.2
  * Author:              Ali Colville
  * Author URI:          https://www.YeKen.uk
@@ -18,7 +18,7 @@ defined('ABSPATH') or die("Jog on!");
  */
 
 define( 'YK_MT_ABSPATH', plugin_dir_path( __FILE__ ) );
-define( 'YK_MT_PLUGIN_VERSION', '3.1.4' );
+define( 'YK_MT_PLUGIN_VERSION', '3.1.5' );
 define( 'YK_MT_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
 define( 'YK_MT_SLUG', 'meal-tracker' );
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: aliakro
 Donate link: https://www.paypal.me/yeken
 Tags: meal, tracker, calories, weight, food, fatsecrets, collection, macronutrients, fractions, search, edit, create
 Requires at least: 5.7
-Tested up to: 6.3
-Stable tag: 3.1.4
+Tested up to: 6.3.2
+Stable tag: 3.1.5
 Requires PHP: 7.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -86,6 +86,10 @@ The plugin is written in English (UK) but is ready for translation. If you wish 
 3.1 - Communicate and search with meal collections from other WP installs with Meal Tracker installed.
 
 == Changelog ==
+
+= 3.1.5 =
+
+* Improvement: When a user is on the Meal Tracker settings tab, if they have not specified all of their user profile in Weight Tracker, then warn them that "Weight Tracker" can not be used as a source.
 
 = 3.1.4 =
 


### PR DESCRIPTION
* Improvement: When a user is on the Meal Tracker settings tab, if they have not specified all of their user profile in Weight Tracker, then warn them that "Weight Tracker" can not be used as a source.
